### PR TITLE
Fix workout modal

### DIFF
--- a/client/src/components/Calendar/index.js
+++ b/client/src/components/Calendar/index.js
@@ -85,22 +85,13 @@ class Calendar extends Component {
                     <Table.Row>
                         {week.map((day) => {
                             return(
-                                <Modal 
+                                <ModalWorkout 
                                     trigger={<Table.Cell value={day}>
-                                            {day}
-                                            </Table.Cell>} 
-                                    style={{marginTop: "10%", marginLeft: "10%", marginRight: "10%"}}>
-                                    <Modal.Header>Log Workout</Modal.Header>
-                                        <Modal.Content image>
-                                        <Modal.Description>
-                                            <Header></Header>
-                                                <FormWorkout 
-                                                    thisDay={padDate(day.toString())} 
-                                                    thisMonth={padDate((this.state.month + 1).toString())} 
-                                                    thisYear={this.state.year}/>
-                                        </Modal.Description>
-                                        </Modal.Content>
-                                </Modal>
+                                                {day}
+                                            </Table.Cell>}
+                                    thisDay={padDate(day.toString())} 
+                                    thisMonth={padDate((this.state.month + 1).toString())} 
+                                    thisYear={this.state.year}/>
                             );
                         })}
                     </Table.Row>

--- a/client/src/components/FormWorkout/index.js
+++ b/client/src/components/FormWorkout/index.js
@@ -17,8 +17,8 @@ class FormWorkout extends Component {
 
   render() {
     return (
-      <Form onSubmit={() => this.handleSubmit(this.props.formData)}>
-        <Form.Group widths='equal'>
+      <Form>
+        <Form.Group>
             <SearchBar />
             <Form.Field>
               <input type='date' defaultValue={this.state.date}/>
@@ -29,12 +29,14 @@ class FormWorkout extends Component {
           <ListAvailableExercises/>
         </Form.Group>
         <Form.Field 
+         type='button'
           control={Button}
-          onClick={console.log(this.props.handleClose)}>
+          onClick={() => this.handleSubmit(this.props.formData)}>
           Save</Form.Field>
       </Form>
     )
   }
+
   handleSubmit(formData){
     fetch("/api/workout/save",{
       method: 'POST',
@@ -45,9 +47,9 @@ class FormWorkout extends Component {
           'Accept': 'application/json, */*',
           'Content': 'application/json',
       }
-      }).then(response => {
-        //console.log(response);
-      })
+      }).then(
+        this.props.handleClose
+      )
       .catch(err => console.log('Error: ' + err))
   }
 }

--- a/client/src/components/ModalWorkout/index.js
+++ b/client/src/components/ModalWorkout/index.js
@@ -13,12 +13,13 @@ class ModalWorkout extends Component {
 
     open = () => this.setState({ open: true })
     close = () => this.setState({ open: false })
-   
+    
     render(){
         const { open } = this.state
+        let trigger = this.props.trigger || <Button>+</Button>
         return(
             <Modal 
-                trigger={<Button>+</Button>} 
+                trigger={trigger} 
                 style={{marginTop: "10%", marginLeft: "10%", marginRight: "10%"}}
                 open={open}
                 onOpen={this.open}
@@ -27,7 +28,11 @@ class ModalWorkout extends Component {
                 <Modal.Content image>
                     <Modal.Description>
                         <Header></Header>
-                            <FormWorkout handleClose={this.close}/>
+                            <FormWorkout 
+                                handleClose={this.close}
+                                thisDay={this.props.thisDay} 
+                                thisMonth={this.props.thisMonth} 
+                                thisYear={this.props.thisYear}/>
                     </Modal.Description>
                 </Modal.Content>
             </Modal>


### PR DESCRIPTION
## Reference
- Original [Asana Task](https://app.asana.com/0/622910146909793/659144820435623)

## Overview

This PR makes the modal where a user logs a workout close and save the workout when a user clicks the Save button. It also refactors the Calendar component to use the ModalWorkout component versus rewriting the modal code in the Calendar.


## Testing Instructions

-npm install && cd client && npm install && cd ..
-npm start
-http://localhost:3000/dashboard
--Displays the + icon to add workout. 
--Adding exercise and hitting Save will save to DB and close modal
-http://localhost:3000/calendar
--Displays calendar month. Hitting a day will open the modal with the date pre-populated.
--Adding exercise and hitting Save will save to DB and close modal